### PR TITLE
Move to a Fedora 30 based container image

### DIFF
--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,26 +1,18 @@
-FROM openjdk:11
+FROM registry.fedoraproject.org/fedora-minimal:30
 LABEL maintainer="Digirati <opensource@digirati.com>"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get clean \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        python3=3.5.3-1 \
-        python3-pip=9.0.1-2+deb9u1 \
-        python3-setuptools=33.1.1-1 \
-        python3-wheel=0.29.0-2 \
-        software-properties-common=0.96.20.2-1 \
-        lsb-release=9.20161125 \
-        apt-transport-https=1.4.9 \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
-    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends docker-ce=5:18.09.6~3-0~debian-stretch \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
+RUN microdnf install \
+        git \
+        java-latest-openjdk \
+        java-latest-openjdk-headless \
+        java-latest-openjdk-devel \
+        python3 \
+        python3-pip \
+        docker \
+    && microdnf clean all \
+    && pip3 install pre-commit==1.16.1 \
     && useradd -rm -d /home/build -s /bin/bash -u 1000 build
 
-RUN pip3 install pre-commit==1.16.1
-
+ENV JAVA_HOME="/usr/lib/jvm/java"
 USER build
-WORKDIR /home/build


### PR DESCRIPTION
Given the issues that have arisen from the Debian OpenJDK packages (and
subsequent Docker builds), the build image has been switched to a Fedora
container with a Red Hat OpenJDK build. The reasoning here is the Java
packaging team at Debian does not have a great track record when it comes to
producing reliable packages.

To summarize:

  * Debian pushed buggy pre-release packages to stable and stable-backports.
  * Debian was not involved in producing the OpenJDK Docker images at
    DockerHub.
  * The OpenJDK image published to DockerHub incorrectly uses the
    OpenJDK trademark, when it is not an official product of the OpenJDK project.

The rationale behind moving to a Red Hat build of OpenJDK is driven by them being the lead maintainers of the OpenJDK project, giving us binaries as close to the GPL'd OpenJDK releases currently available from Oracle.